### PR TITLE
Fix timestamp defaults in PynamoDB models

### DIFF
--- a/aws-python-pynamodb-s3-sigurl/asset/asset_model.py
+++ b/aws-python-pynamodb-s3-sigurl/asset/asset_model.py
@@ -33,8 +33,10 @@ class AssetModel(Model):
 
     asset_id = UnicodeAttribute(hash_key=True)
     state = UnicodeAttribute(null=False, default=State.CREATED.name)
-    createdAt = UTCDateTimeAttribute(null=False, default=datetime.now().astimezone())
-    updatedAt = UTCDateTimeAttribute(null=False, default=datetime.now().astimezone())
+    # Default timestamps should be generated at save time to avoid sharing the
+    # same value across instances when the module is imported.
+    createdAt = UTCDateTimeAttribute(null=False, default=lambda: datetime.now().astimezone())
+    updatedAt = UTCDateTimeAttribute(null=False, default=lambda: datetime.now().astimezone())
 
     def __str__(self):
         return 'asset_id:{}, state:{}'.format(self.asset_id, self.state)

--- a/aws-python-rest-api-with-pynamodb/todos/todo_model.py
+++ b/aws-python-rest-api-with-pynamodb/todos/todo_model.py
@@ -17,7 +17,8 @@ class TodoModel(Model):
     todo_id = UnicodeAttribute(hash_key=True, null=False)
     text = UnicodeAttribute(null=False)
     checked = BooleanAttribute(null=False)
-    createdAt = UTCDateTimeAttribute(null=False, default=datetime.now())
+    # Use callable defaults so each record gets the current timestamp on creation
+    createdAt = UTCDateTimeAttribute(null=False, default=datetime.utcnow)
     updatedAt = UTCDateTimeAttribute(null=False)
 
     def save(self, conditional_operator=None, **expected_values):


### PR DESCRIPTION
## Summary
- ensure UTC timestamps are generated at save time in Python PynamoDB models

## Testing
- `npm run validate`
- `python -m py_compile aws-python-rest-api-with-pynamodb/todos/*.py aws-python-pynamodb-s3-sigurl/asset/asset_model.py`


------
https://chatgpt.com/codex/tasks/task_e_68411e1afd0c83268c14e115211f3d8f